### PR TITLE
Users and notifications tables cleaning

### DIFF
--- a/models/staging/raw/notifications_clean.sql
+++ b/models/staging/raw/notifications_clean.sql
@@ -1,0 +1,12 @@
+SELECT 
+
+reason,
+channel,
+status,
+user_id,
+EXTRACT(year FROM created_date) AS creation_year,
+EXTRACT(month FROM created_date) AS creation_month,
+EXTRACT(day FROM created_date) AS creation_day,
+EXTRACT(hour FROM created_date) AS creation_hour
+
+FROM {{ ref('stg_raw__notifications') }}

--- a/models/staging/raw/users_clean.sql
+++ b/models/staging/raw/users_clean.sql
@@ -1,0 +1,43 @@
+WITH table1 AS
+(SELECT
+user_id,
+birth_year,
+country,
+EXTRACT(year FROM created_date) AS creation_year,
+EXTRACT(month FROM created_date) AS creation_month,
+EXTRACT(day FROM created_date) AS creation_day,
+EXTRACT(hour FROM created_date) AS creation_hour,
+user_settings_crypto_unlocked,
+plan,
+CAST(attributes_notifications_marketing_email AS INTEGER) as attributes_notifications_marketing_email,
+CAST(attributes_notifications_marketing_push AS INTEGER) as attributes_notifications_marketing_push,
+num_contacts,
+num_referrals,
+num_successful_referrals
+FROM {{ ref('stg_raw__users') }})
+
+
+SELECT 
+user_id,
+birth_year,
+country,
+creation_year,
+creation_month,
+creation_day,
+creation_hour,
+user_settings_crypto_unlocked,
+plan,
+CASE 
+    WHEN attributes_notifications_marketing_push = 1 THEN '1'
+    WHEN attributes_notifications_marketing_push = 0 THEN '0'
+    ELSE 'No answer' 
+END AS attributes_notifications_marketing_push,
+CASE 
+    WHEN attributes_notifications_marketing_email = 1 THEN '1'
+    WHEN attributes_notifications_marketing_email = 0 THEN '0'
+    ELSE 'No answer' 
+END AS attributes_notifications_marketing_email,
+num_contacts,
+num_referrals,
+num_successful_referrals
+FROM table1

--- a/models/staging/users_clean.sql
+++ b/models/staging/users_clean.sql
@@ -1,1 +1,0 @@
-select * from {{ ref('stg_raw__users') }}


### PR DESCRIPTION
**Table NOTIFICATIONS :**

We’ve splited and removed the column "created_date”,
originally in format “YEAR-MM-DD HH:MM:SS.XXX UTC”,
into the following new columns : 

- created_year
- created_month
- created_day
- created_hour


**Table USERS :**

We’ve removed the column “city”. It’s a bit of mess (postal code etc instead of pure text…) and it won’t impact our analysis.

We’ve splited and removed the column "created_date”,
originally in format “YEAR-MM-DD HH:MM:SS.XXX UTC”,
into the following new columns : 

- created_year
- created_month
- created_day
- created_hour

Column “attributes_notifications_marketing_push” and “attributes_notifications_marketing_email”. There were 3 possibles outputs : “`1`”, “`0`", and “`Null`".

For unknown technical reason, it was not possible to replace the “`Null`" values per something else uniquely (e.g: “`CASE WHEN attributes_notifications_marketing_push IS NULL`”. It didn’t worked for all the rows.

We had to make a :

`CASE WHEN .... = 1 THEN 1 .... = 0 THEN 0 ....ELSE "No answer"`