### PR TITLE
- created new segmentation of churner

### DIFF
--- a/models/Intermediate/user_merged.sql
+++ b/models/Intermediate/user_merged.sql
@@ -3,11 +3,17 @@ SELECT
 U.*,
 d.device,
 c.* EXCEPT(user_id),
-chr.is_churner,
 chr.diff_last_today,
-chr.last_transaction_date
+chr.last_transaction_date,
+
+CASE WHEN diff_last_today >= 92 AND turnover_by_user < 20 THEN 1 -- perdu
+    WHEN diff_last_today >= 35 AND turnover_by_user >= 40 THEN 2 -- top client à risque 
+    ELSE 0 
+END AS is_churner
 
 FROM{{ ref('users_clean') }} AS U
 LEFT JOIN {{ ref('devices_clean') }} AS d on U.user_id = d.user_id 
 LEFT JOIN {{ ref('churner_count_agrg') }} as c on U.user_id = c.user_id
 LEFT JOIN {{ ref('Definition_churner_transaction') }} as chr on U.user_id = chr.user_id
+WHERE nb_transaction IS NOT NULL
+ORDER BY is_churner ASC


### PR DESCRIPTION
First category no transaction in the last 92 days and the sum of tx is under 50* of lifetime value Second category top users who didn't make any tx in the last 35 days and turnover > at the mean life time value